### PR TITLE
Fix basic auth in case of missing `authorization` header

### DIFF
--- a/src/macchiato/auth/backends/basic.cljs
+++ b/src/macchiato/auth/backends/basic.cljs
@@ -14,9 +14,10 @@
                          (re-find pattern)
                          (second)
                          (b64/decodeString))]
-    (when-let [[username password] (s/split decoded #":" 2)]
-      {:username username
-       :password password})))
+    (when decoded
+      (when-let [[username password] (s/split decoded #":" 2)]
+        {:username username
+         :password password}))))
 
 (defn http-basic-backend
   [{:keys [realm authfn unauthorized-handler] :or {realm "Macchiato Auth"}}]

--- a/test/macchiato/test/auth/core_test.cljs
+++ b/test/macchiato/test/auth/core_test.cljs
@@ -79,6 +79,9 @@
         (is (= ((mw/wrap-authentication auth-handler) request identity identity)
                request))))))
 
+(defn request [uri method]
+  {:uri uri
+   :method method})
 
 (defn basic-auth-request [uri method]
   {:uri     uri
@@ -90,16 +93,23 @@
    :method  method
    :session session})
 
-#_(deftest basic-backend-test
-    (let [handler (mw/wrap-authentication
-                    (fn [req res raise]
-                      (println "got req" req)
-                      (res req))
-                    (basic/http-basic-backend
-                      {:authfn (fn [_] true)}))]
-      (handler (basic-auth-request "/" :post)
-               identity
-               identity)))
+(deftest basic-backend-test
+  (let [handler (mw/wrap-authentication
+                 (fn [req res raise]
+                   (println "got req" req)
+                   (res req))
+                 (basic/http-basic-backend
+                  {:authfn (fn [_] true)}))]
+    (testing "With authorization header"
+      (let [response (handler (basic-auth-request "/" :post)
+                              identity
+                              identity)]
+        (is (= true (:identity response)))))
+    (testing "Without authorization header"
+      (let [response (handler (request "/" :post)
+                              identity
+                              identity)]
+        (is (= nil (:identity response)))))))
 
 #_(deftest session-backend-test
     (let [handler (mw/wrap-authentication


### PR DESCRIPTION
Before:

```
ERROR in (basic-backend-test) (TypeError:NaN:NaN)
Uncaught exception, not in assertion.
expected: nil
  actual: #object[TypeError TypeError: re-find must match against a string.]
```